### PR TITLE
set_xcconfig_value writes a new entry if the key does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Gemfile.lock
 /rdoc/
 fastlane/README.md
 fastlane/report.xml
+fastlane/Configs/Test.xcconfig
 coverage
 test-results
 

--- a/fastlane/Configs/Release.xcconfig
+++ b/fastlane/Configs/Release.xcconfig
@@ -1,1 +1,0 @@
-PRODUCT_BUNDLE_IDENTIFIER = com.sovcharenko.App

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,15 +1,24 @@
 lane :test do
+  sh("echo 'PRODUCT_BUNDLE_IDENTIFIER = com.sovcharenko.app' > Configs/Test.xcconfig")
+
   # Read PRODUCT_BUNDLE_IDENTIFIER value from Configs/Release.xcconfig
   bundle_id = get_xcconfig_value(
-    path: 'fastlane/Configs/Release.xcconfig',
+    path: 'fastlane/Configs/Test.xcconfig',
     name: 'PRODUCT_BUNDLE_IDENTIFIER'
   )
   puts("Bundle ID: #{bundle_id}")
 
-  # Sets PRODUCT_BUNDLE_IDENTIFIER value to 'com.sovcharenko.App-beta' in Configs/Release.xcconfig
+  # Sets PRODUCT_NAME value to 'App' in Configs/Test.xcconfig
   set_xcconfig_value(
-    path: 'fastlane/Configs/Release.xcconfig',
-    name: 'PRODUCT_BUNDLE_IDENTIFIER',
-    value: 'com.sovcharenko.App-beta'
+    path: 'fastlane/Configs/Test.xcconfig',
+    name: 'PRODUCT_NAME',
+    value: 'App'
+  )
+
+  # Update PRODUCT_NAME value to 'Updated App' in Configs/Test.xcconfig
+  update_xcconfig_value(
+    path: 'fastlane/Configs/Test.xcconfig',
+    name: 'PRODUCT_NAME',
+    value: 'Updated App'
   )
 end

--- a/lib/fastlane/plugin/xcconfig/actions/set_xcconfig_value_action.rb
+++ b/lib/fastlane/plugin/xcconfig/actions/set_xcconfig_value_action.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         path = File.expand_path(params[:path])
 
-        tmp_file = path + '.updated'
+        tmp_file = path + '.set'
 
         name = params[:name]
 
@@ -28,12 +28,13 @@ module Fastlane
                 file.write(name + ' = ' + value + "\n")
                 updated = true
               else
-                file.write(line)
+                file.write(line.strip + "\n")
               end
             end
+            file.write(name + ' = ' + value) unless updated
           end
 
-          Fastlane::UI.user_error!("Couldn't find '#{name}' in #{path}.") unless updated
+          Fastlane::UI.message("Set `#{name}` to `#{value}`")
 
           FileUtils.cp(tmp_file, path)
         ensure
@@ -42,11 +43,11 @@ module Fastlane
       end
 
       def self.description
-        'Updates value of a setting in xcconfig file.'
+        'Sets the value of a setting in xcconfig file.'
       end
 
       def self.authors
-        ["Sergii Ovcharenko"]
+        ["Sergii Ovcharenko", "steprescott"]
       end
 
       def self.return_value
@@ -54,7 +55,7 @@ module Fastlane
       end
 
       def self.details
-        'This action updates the value of a given setting in a given xcconfig file. Will throw an error if specified setting doesn\'t exist'
+        'This action sets the value of a given setting in a given xcconfig file.'
       end
 
       def self.available_options

--- a/lib/fastlane/plugin/xcconfig/actions/update_xcconfig_value_action.rb
+++ b/lib/fastlane/plugin/xcconfig/actions/update_xcconfig_value_action.rb
@@ -1,0 +1,90 @@
+require 'fastlane/action'
+require_relative '../helper/xcconfig_helper'
+
+module Fastlane
+  module Actions
+    class UpdateXcconfigValueAction < Action
+      def self.run(params)
+        path = File.expand_path(params[:path])
+
+        tmp_file = path + '.updated'
+
+        name = params[:name]
+
+        # Revert fastlane's auto conversion of strings into booleans
+        # https://github.com/fastlane/fastlane/pull/11923
+        value = if [true, false].include?(params[:value])
+                  params[:value] ? 'YES' : 'NO'
+                else
+                  params[:value].strip
+                end
+        begin
+          updated = false
+
+          File.open(tmp_file, 'w') do |file|
+            File.open(path).each do |line|
+              xcname, = Helper::XcconfigHelper.parse_xcconfig_name_value_line(line)
+              if xcname == name
+                file.write(name + ' = ' + value + "\n")
+                updated = true
+              else
+                file.write(line)
+              end
+            end
+          end
+
+          Fastlane::UI.user_error!("Couldn't find '#{name}' in #{path}.") unless updated
+          Fastlane::UI.message("Updated `#{name}` to `#{value}`")
+
+          FileUtils.cp(tmp_file, path)
+        ensure
+          File.delete(tmp_file)
+        end
+      end
+
+      def self.description
+        'Updates value of a setting in xcconfig file.'
+      end
+
+      def self.authors
+        ["Sergii Ovcharenko", "steprescott"]
+      end
+
+      def self.return_value
+        nil
+      end
+
+      def self.details
+        'This action updates the value of a given setting in a given xcconfig file. Will throw an error if specified setting doesn\'t exist'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :name,
+                                       env_name: "XCCP_UPDATE_VALUE_PARAM_NAME",
+                                       description: "Name of key in xcconfig file to update",
+                                       type: String,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :value,
+                                       env_name: "XCCP_UPDATE_VALUE_PARAM_VALUE",
+                                       description: "Value to set",
+                                       skip_type_validation: true, # skipping type validation as fastlane converts YES/NO/true/false strings into booleans
+                                       type: String,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: "XCCP_UPDATE_VALUE_PARAM_PATH",
+                                       description: "Path to xcconfig file you want to update",
+                                       type: String,
+                                       optional: false,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Couldn't find xcconfig file at path '#{value}'") unless File.exist?(File.expand_path(value))
+                                       end)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/xcconfig/version.rb
+++ b/lib/fastlane/plugin/xcconfig/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Xcconfig
-    VERSION = "1.0.0"
+    VERSION = "2.0.0"
   end
 end

--- a/spec/specs/fixtures/update.xcconfig
+++ b/spec/specs/fixtures/update.xcconfig
@@ -1,0 +1,21 @@
+// Import base application settings
+#include "../Base/Targets/Application.xcconfig"
+
+EMPTY =
+
+// Architectures to build
+ARCHS = $(ARCHS_STANDARD)
+
+// Warn about loop bodies that are suspiciously empty.
+CLANG_WARN_EMPTY_BODY = YES
+
+PRODUCT_BUNDLE_IDENTIFIER = com.sovcharenko.App // PRODUCT_BUNDLE_IDENTIFIER = com.sovcharenko.App-beta
+
+    ONLY_ACTIVE_ARCH[config=Debug][sdk=*][arch=*]    =  YES
+    ONLY_ACTIVE_ARCH[config=Release]                 =  NO
+
+//Invalid settings
+1FOO = BAR
+FOO
+FOO//BAR = FOOBAR
+FOO BAR

--- a/spec/specs/set_xcconfig_value_action_spec.rb
+++ b/spec/specs/set_xcconfig_value_action_spec.rb
@@ -38,9 +38,19 @@ describe Fastlane::Actions::SetXcconfigValueAction do
       end
     end
 
-    it 'raises error when setting couldn\'t be found' do
-      expect { set_xcconfig_value('some_name', 'new_value') }.to raise_exception do |exception|
-        expect(exception.message).to start_with('Couldn\'t find \'some_name\' in')
+    it 'sets value' do
+      {
+        'EMPTY' => 'new_value',
+        'ARCHS' => 'nil',
+        'CLANG_WARN_EMPTY_BODY' => 'NO',
+        'PRODUCT_BUNDLE_IDENTIFIER' => 'com.sovcharenko.App-beta',
+        'ONLY_ACTIVE_ARCH[config=Debug][sdk=*][arch=*]' => 'NO',
+        'ONLY_ACTIVE_ARCH[config=Release]' => 'YES',
+        'NEW' => 'VALUE'
+      }.each do |key, value|
+        before, after = set_xcconfig_value(key, value)
+        expect(after.attributes[key]).to eq(value)
+        expect(after.attributes.except!(key)).to eq(before.attributes.except!(key))
       end
     end
 

--- a/spec/specs/update_xcconfig_value_action_spec.rb
+++ b/spec/specs/update_xcconfig_value_action_spec.rb
@@ -1,0 +1,62 @@
+require 'xcodeproj'
+
+# https://stackoverflow.com/questions/6227600/how-to-remove-a-key-from-hash-and-get-the-remaining-hash-in-ruby-rails
+class Hash
+  def except!(*keys)
+    keys.each { |key| delete(key) }
+    self
+  end
+end
+
+describe Fastlane::Actions::UpdateXcconfigValueAction do
+  describe '#run' do
+    def update_xcconfig_value(name, value, file = "update.xcconfig")
+      tmp_dir = Dir.mktmpdir('fastlane-plugin-xcconfig ')
+      begin
+        path = File.join(File.dirname(__FILE__), "fixtures/#{file}")
+        before_content = nil
+
+        if File.exist?(path)
+          FileUtils.cp(path, tmp_dir)
+          path = File.join(tmp_dir, file)
+          before_content = Xcodeproj::Config.new(path)
+        end
+
+        SpecHelper::FastlaneHelper.execute_as_lane("update_xcconfig_value(path:'#{path}', name: '#{name}', value: '#{value}')")
+
+        after_content = Xcodeproj::Config.new(Xcodeproj::Config.new(path))
+
+        [before_content, after_content]
+      ensure
+        FileUtils.rm_rf(tmp_dir)
+      end
+    end
+
+    it 'raises error when file doesn\'t exist' do
+      expect { update_xcconfig_value('name1', 'new_value', 'non_existent_file.xcconfig') }.to raise_exception do |exception|
+        expect(exception.message).to start_with('Couldn\'t find xcconfig file at path')
+      end
+    end
+
+    it 'raises error when setting couldn\'t be found' do
+      expect { update_xcconfig_value('some_name', 'new_value') }.to raise_exception do |exception|
+        expect(exception.message).to start_with('Couldn\'t find \'some_name\' in')
+      end
+    end
+
+    it 'updates value' do
+      {
+        'EMPTY' => 'new_value',
+        'ARCHS' => 'nil',
+        'CLANG_WARN_EMPTY_BODY' => 'NO',
+        'PRODUCT_BUNDLE_IDENTIFIER' => 'com.sovcharenko.App-beta',
+        'ONLY_ACTIVE_ARCH[config=Debug][sdk=*][arch=*]' => 'NO',
+        'ONLY_ACTIVE_ARCH[config=Release]' => 'YES'
+      }.each do |key, value|
+        before, after = update_xcconfig_value(key, value)
+        expect(after.attributes[key]).to eq(value)
+        expect(after.attributes.except!(key)).to eq(before.attributes.except!(key))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1 

When using `.xcconfig` files it is possible to `#import` another `.xcconfig` file. The example below shows an example that gives reason why this change is needed.

**common.xcconfig**
```
PRODUCT_NAME = App
```
**app.xcconfig**
```
PRODUCT_BUNDLE_ID = com.some.app
```

Now if I want to update the `PRODUCT_NAME` in `app.xcconfig` currently this will fail as `PRODUCT_NAME` is in the `common.xcconfig` so without the need to build the logic to see if an `#import` and check those files it will give the same affect by just adding the same key into `app.xcconfig`

To allow for the previous behaviour I have renamed it to `update_xcconfig_value` and modified `set_xcconfig_value` to update the value if it is there and if not add it.