### PR TITLE
Adds option to hide value from being printed to UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ lane :test do
     value: 'Updated App'
   )
 
+  # Updates the value and hides it from being printed to the UI.
+  # Used to hide sensitive data from being displayed in logs.
+  update_xcconfig_value(
+    path: 'fastlane/Test.xcconfig',
+    name: 'PRODUCT_NAME',
+    value: 'Updated App Hidden',
+    mask_value: true
+  )
+
   # Sets PRODUCT_BUNDLE_IDENTIFIER value to 'com.sovcharenko.App-beta' in Configs/Release.xcconfig
   # PRODUCT_BUNDLE_IDENTIFIER will be added if it doesn't exist
   set_xcconfig_value(

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ lane :test do
     value: 'com.sovcharenko.App-beta'
   )
 
+  # Sets the value and hides it from printed to the UI.
+  # Used to hide sensitive data from being displayed in logs.
+  set_xcconfig_value(
+    path: 'fastlane/Configs/Release.xcconfig',
+    name: 'PRODUCT_BUNDLE_IDENTIFIER',
+    value: 'com.sovcharenko.App-beta',
+    hide_value_output: true
+  )
+
 end
 
 ```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ lane :test do
     path: 'fastlane/Configs/Release.xcconfig',
     name: 'PRODUCT_BUNDLE_IDENTIFIER',
     value: 'com.sovcharenko.App-beta',
-    hide_value_output: true
+    mask_value: true
   )
 
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,14 @@ lane :test do
     value: 'App'
   )
 
+   # Sets PRODUCT_NAME value to 'AppHidden' in Configs/Test.xcconfig and hides the value output
+   set_xcconfig_value(
+    path: 'fastlane/Test.xcconfig',
+    name: 'PRODUCT_NAME',
+    value: 'AppHidden',
+    hide_value_output: true
+  )
+
   # Update PRODUCT_NAME value to 'Updated App' in Configs/Test.xcconfig
   update_xcconfig_value(
     path: 'fastlane/Test.xcconfig',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,7 +20,7 @@ lane :test do
     path: 'fastlane/Test.xcconfig',
     name: 'PRODUCT_NAME',
     value: 'AppHidden',
-    hide_value_output: true
+    mask_value: true
   )
 
   # Update PRODUCT_NAME value to 'Updated App' in Configs/Test.xcconfig

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,8 +15,8 @@ lane :test do
     value: 'App'
   )
 
-   # Sets PRODUCT_NAME value to 'AppHidden' in Configs/Test.xcconfig and hides the value output
-   set_xcconfig_value(
+  # Sets PRODUCT_NAME value to 'AppHidden' in Configs/Test.xcconfig and hides the value output
+  set_xcconfig_value(
     path: 'fastlane/Test.xcconfig',
     name: 'PRODUCT_NAME',
     value: 'AppHidden',
@@ -28,5 +28,13 @@ lane :test do
     path: 'fastlane/Test.xcconfig',
     name: 'PRODUCT_NAME',
     value: 'Updated App'
+  )
+
+  # Update PRODUCT_NAME value to 'Updated App Hidden' in Configs/Test.xcconfig and hides the value output
+  update_xcconfig_value(
+    path: 'fastlane/Test.xcconfig',
+    name: 'PRODUCT_NAME',
+    value: 'Updated App Hidden',
+    mask_value: true
   )
 end

--- a/lib/fastlane/plugin/xcconfig/actions/set_xcconfig_value_action.rb
+++ b/lib/fastlane/plugin/xcconfig/actions/set_xcconfig_value_action.rb
@@ -34,8 +34,8 @@ module Fastlane
             file.write(name + ' = ' + value) unless updated
           end
 
-          if params[:hide_value_output]
-            Fastlane::UI.message("Value updated for key: `#{name}`")
+          if params[:mask_value]
+            Fastlane::UI.message("Set `#{name}` to `****`")
           else
             Fastlane::UI.message("Set `#{name}` to `#{value}`")
           end
@@ -83,9 +83,9 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find xcconfig file at path '#{value}'") unless File.exist?(File.expand_path(value))
                                        end),
-          FastlaneCore::ConfigItem.new(key: :hide_value_output,
-                                        env_name: "XCCP_SET_VALUE_PARAM_HIDE_VALUE_OUTPUT",
-                                        description: "Stops the outuput of the value being printed to the console",
+          FastlaneCore::ConfigItem.new(key: :mask_value,
+                                        env_name: "XCCP_SET_VALUE_PARAM_MASK_VALUE",
+                                        description: "Masks the value from being printed to the console",
                                         optional: true,
                                         is_string: false,
                                         default_value: false)

--- a/lib/fastlane/plugin/xcconfig/actions/set_xcconfig_value_action.rb
+++ b/lib/fastlane/plugin/xcconfig/actions/set_xcconfig_value_action.rb
@@ -34,7 +34,11 @@ module Fastlane
             file.write(name + ' = ' + value) unless updated
           end
 
-          Fastlane::UI.message("Set `#{name}` to `#{value}`")
+          if params[:hide_value_output]
+            Fastlane::UI.message("Value updated for key: `#{name}`")
+          else
+            Fastlane::UI.message("Set `#{name}` to `#{value}`")
+          end
 
           FileUtils.cp(tmp_file, path)
         ensure
@@ -78,7 +82,13 @@ module Fastlane
                                        optional: false,
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find xcconfig file at path '#{value}'") unless File.exist?(File.expand_path(value))
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :hide_value_output,
+                                        env_name: "XCCP_SET_VALUE_PARAM_HIDE_VALUE_OUTPUT",
+                                        description: "Stops the outuput of the value being printed to the console",
+                                        optional: true,
+                                        is_string: false,
+                                        default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/xcconfig/actions/update_xcconfig_value_action.rb
+++ b/lib/fastlane/plugin/xcconfig/actions/update_xcconfig_value_action.rb
@@ -34,7 +34,11 @@ module Fastlane
           end
 
           Fastlane::UI.user_error!("Couldn't find '#{name}' in #{path}.") unless updated
-          Fastlane::UI.message("Updated `#{name}` to `#{value}`")
+          if params[:mask_value]
+            Fastlane::UI.message("Updated `#{name}` to `****`")
+          else
+            Fastlane::UI.message("Updated `#{name}` to `#{value}`")
+          end
 
           FileUtils.cp(tmp_file, path)
         ensure
@@ -78,7 +82,13 @@ module Fastlane
                                        optional: false,
                                        verify_block: proc do |value|
                                          UI.user_error!("Couldn't find xcconfig file at path '#{value}'") unless File.exist?(File.expand_path(value))
-                                       end)
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :mask_value,
+                                        env_name: "XCCP_SET_VALUE_PARAM_MASK_VALUE",
+                                        description: "Masks the value from being printed to the console",
+                                        optional: true,
+                                        is_string: false,
+                                        default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/xcconfig/actions/update_xcconfig_value_action.rb
+++ b/lib/fastlane/plugin/xcconfig/actions/update_xcconfig_value_action.rb
@@ -84,7 +84,7 @@ module Fastlane
                                          UI.user_error!("Couldn't find xcconfig file at path '#{value}'") unless File.exist?(File.expand_path(value))
                                        end),
           FastlaneCore::ConfigItem.new(key: :mask_value,
-                                        env_name: "XCCP_SET_VALUE_PARAM_MASK_VALUE",
+                                        env_name: "XCCP_UPDATE_VALUE_PARAM_MASK_VALUE",
                                         description: "Masks the value from being printed to the console",
                                         optional: true,
                                         is_string: false,

--- a/lib/fastlane/plugin/xcconfig/version.rb
+++ b/lib/fastlane/plugin/xcconfig/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Xcconfig
-    VERSION = "2.0.1"
+    VERSION = "2.1.0"
   end
 end

--- a/lib/fastlane/plugin/xcconfig/version.rb
+++ b/lib/fastlane/plugin/xcconfig/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Xcconfig
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end

--- a/spec/specs/set_xcconfig_value_action_spec.rb
+++ b/spec/specs/set_xcconfig_value_action_spec.rb
@@ -10,7 +10,7 @@ end
 
 describe Fastlane::Actions::SetXcconfigValueAction do
   describe '#run' do
-    def set_xcconfig_value(name, value, file = "set.xcconfig")
+    def set_xcconfig_value(name, value, file = "set.xcconfig", hide_value_output = false)
       tmp_dir = Dir.mktmpdir('fastlane-plugin-xcconfig ')
       begin
         path = File.join(File.dirname(__FILE__), "fixtures/#{file}")
@@ -22,7 +22,7 @@ describe Fastlane::Actions::SetXcconfigValueAction do
           before_content = Xcodeproj::Config.new(path)
         end
 
-        SpecHelper::FastlaneHelper.execute_as_lane("set_xcconfig_value(path:'#{path}', name: '#{name}', value: '#{value}')")
+        SpecHelper::FastlaneHelper.execute_as_lane("set_xcconfig_value(path:'#{path}', name: '#{name}', value: '#{value}', hide_value_output: '#{hide_value_output}')")
 
         after_content = Xcodeproj::Config.new(Xcodeproj::Config.new(path))
 

--- a/spec/specs/set_xcconfig_value_action_spec.rb
+++ b/spec/specs/set_xcconfig_value_action_spec.rb
@@ -10,7 +10,7 @@ end
 
 describe Fastlane::Actions::SetXcconfigValueAction do
   describe '#run' do
-    def set_xcconfig_value(name, value, file = "set.xcconfig", hide_value_output = false)
+    def set_xcconfig_value(name, value, file = "set.xcconfig", mask_value = false)
       tmp_dir = Dir.mktmpdir('fastlane-plugin-xcconfig ')
       begin
         path = File.join(File.dirname(__FILE__), "fixtures/#{file}")
@@ -22,7 +22,7 @@ describe Fastlane::Actions::SetXcconfigValueAction do
           before_content = Xcodeproj::Config.new(path)
         end
 
-        SpecHelper::FastlaneHelper.execute_as_lane("set_xcconfig_value(path:'#{path}', name: '#{name}', value: '#{value}', hide_value_output: '#{hide_value_output}')")
+        SpecHelper::FastlaneHelper.execute_as_lane("set_xcconfig_value(path:'#{path}', name: '#{name}', value: '#{value}', mask_value: '#{mask_value}')")
 
         after_content = Xcodeproj::Config.new(Xcodeproj::Config.new(path))
 

--- a/spec/specs/update_xcconfig_value_action_spec.rb
+++ b/spec/specs/update_xcconfig_value_action_spec.rb
@@ -10,7 +10,7 @@ end
 
 describe Fastlane::Actions::UpdateXcconfigValueAction do
   describe '#run' do
-    def update_xcconfig_value(name, value, file = "update.xcconfig")
+    def update_xcconfig_value(name, value, file = "update.xcconfig", mask_value = false)
       tmp_dir = Dir.mktmpdir('fastlane-plugin-xcconfig ')
       begin
         path = File.join(File.dirname(__FILE__), "fixtures/#{file}")
@@ -22,7 +22,7 @@ describe Fastlane::Actions::UpdateXcconfigValueAction do
           before_content = Xcodeproj::Config.new(path)
         end
 
-        SpecHelper::FastlaneHelper.execute_as_lane("update_xcconfig_value(path:'#{path}', name: '#{name}', value: '#{value}')")
+        SpecHelper::FastlaneHelper.execute_as_lane("update_xcconfig_value(path:'#{path}', name: '#{name}', value: '#{value}', mask_value: '#{mask_value}')")
 
         after_content = Xcodeproj::Config.new(Xcodeproj::Config.new(path))
 


### PR DESCRIPTION
First, thank you for the awesome plugin.

We have been using it with our flow and one of the issues we are currently facing is that we update a few keys and passwords during some of our CI pipelines that their logs can be seen by people outside of our team and the sensitive data is always displayed:

ex:
<img width="472" alt="image" src="https://github.com/sovcharenko/fastlane-plugin-xcconfig/assets/108954825/cd9177f2-71b2-40c9-aaff-0af347cc3ec4">

With this update we can pass a new parameter `hide_value_output` which ensures the value is not present on logs:
<img width="559" alt="image" src="https://github.com/sovcharenko/fastlane-plugin-xcconfig/assets/108954825/297b2da1-53ca-4212-9c66-b1db15a5c92e">

I've updated the version and readme, but please let me know if I need to update any wording.

Thank you!